### PR TITLE
Add TOML Configuration File Support for Default CLI Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ cd repo-context-packager
 pip install -r requirements.txt
 ```
 
-Or manually:
-
-```bash
-pip install GitPython
-```
-
 ### 4. Test the Installation
 
 ```bash
@@ -94,6 +88,21 @@ python repo-scan.py --help
 | `--output [filename]` | `-o`  | Optional | Write results to a file. If no filename is given, defaults to `output.txt`.    |
 | `paths`               | —     | List     | One or more file or directory paths to analyze. Defaults to current directory. |
 | `--recent`            | `-r`  | Flag     | Include only recently modified files (in the last 7 days)                      |
+
+---
+
+### Configuration via TOML
+
+You can also set default options in `.repo-scan-config.toml`. Example:
+
+```toml
+output = "default_output.txt"
+recent = false        # Include only recent files? (true/false)
+verbose = false
+paths = ["src"]        # can be a string or a list of paths
+max_file_size = 16384  # in bytes
+```
+CLI arguments always override values in the config file. If the file exists but is invalid TOML, the tool will exit with an error.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # Core dependencies
 GitPython>=3.1.45
+toml>=0.10.2

--- a/src/repo-scan.py
+++ b/src/repo-scan.py
@@ -6,6 +6,21 @@ import sys
 import time
 import logging
 
+try:
+    import tomllib  # Python 3.11+
+    def toml_load_file(path):
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+except Exception:
+    try:
+        import toml
+        def toml_load_file(path):
+            with open(path, "r", encoding="utf-8") as f:
+                return toml.load(f)
+    except Exception:
+        toml_load_file = None
+
+
 ## Global Variables ###############################################################################
 parser = argparse.ArgumentParser()
 version_num = "0.1.0"
@@ -13,6 +28,7 @@ file_count = 0
 line_count = 0
 MAX_FILE_BYTES = 16 * 1024 # 16KB
 RECENT_DAY = 3000 / (60*60*24)
+CONFIG_FILE = ".repo-scan-config.toml"
 
 ## Parser Arguments ###############################################################################
 parser.add_argument(


### PR DESCRIPTION
##  Summary
This PR adds support for configuration via a TOML dotfile (`.repo-scan-config.toml`), allowing users to set default options without having to pass them as command-line arguments each time.

Closes #10 

---

##  Changes

### `src/repo-scan.py`
- Added support to read `.repo-scan-config.toml` from the current directory
- TOML values are loaded as default options for the script
- CLI arguments still override config values
- Unknown options in the TOML file are ignored
- Handles parsing errors gracefully (exits with a clear error message if TOML is broken)

### `requirements.txt`
- Added `toml` package as a dependency for parsing TOML files

### `README.md`
- Added documentation for `.repo-scan-config.toml`
- Included example config file content
---

##  Usage Example

Create a config file in the project root:

```toml
output = "output.txt"
verbose = true
recent = true
paths = ["src"]
```
Then run the script:

```python
python src/repo-scan.py .
```
The script will use values from the TOML file by default.

---